### PR TITLE
テスト用の AST の生成方法を改善

### DIFF
--- a/tests/Scratch.Runtime.Tests/Scratch.Runtime.Test.Helpers.fs
+++ b/tests/Scratch.Runtime.Tests/Scratch.Runtime.Test.Helpers.fs
@@ -11,7 +11,9 @@ type KnownFooterStatementName = KnownFooterStatementName of Symbol
 [<Struct>]
 type KnownListenerHeaderName = KnownListenerHeaderName of Symbol
 [<Struct>]
-type KnownComplexExpressionName<'a> = KnownComplexExpressionName of Symbol
+type KnownComplexExpressionName = KnownComplexExpressionName of Symbol
+[<Struct>]
+type KnownValueComplexExpressionName = KnownValueComplexExpressionName of Symbol
 
 let nameElements ofString toString names = 
     let gen = names |> Seq.map ofString |> Gen.elements
@@ -24,6 +26,118 @@ let getNonNull = function NonNull x -> x
 
 [<Struct>]
 type FooterStatement<'a> = FooterStatement of 'a ComplexExpression
+let knownListenerHeaderMap = Map knownListenerHeaders
+
+[<Struct>]
+type KnownValueComplexExpression<'a> = KnownValueComplexExpression of 'a ComplexExpression
+
+let complexExpressionArb wrapSymbol (|UnwrapSymbol|) =
+    let literalGen = Arb.generate<_> |> Gen.map Literal
+    let literalOrValueComplexGen = Gen.sized <| fun size ->
+        if size <= 0 then literalGen else
+        Gen.oneof [
+            literalGen
+            Arb.generate<_> |> Gen.scaleSize (fun x -> x / 2) |> Gen.map (fun (KnownValueComplexExpression e) -> Complex e)
+        ]
+    let stringsGen strings = gen {
+        let! state = Arb.generate<_>
+        let! x = Gen.elements strings
+        return [Expression.eString state x]
+    }
+    let blockGen = gen {
+        let! x = Arb.generate<_> |> Gen.scaleSize (fun x -> x / 2)
+        return [Block x]
+    }
+    let valueExpressionGen = gen {
+        let! x = literalOrValueComplexGen
+        return [x]
+    }
+    let listVarGen = gen {
+        let! state = Arb.generate<_>
+        let! NonNull x = Arb.generate<_>
+        return [Expression.eString state x]
+    }
+    let reporterGen = stringsGen ["r"]
+    let rotationGen = stringsGen ["left-right"; "don't rotate"; "normal"]
+    let stopGen = stringsGen ["other scripts in sprite"; "other scripts in stage"]
+    let stopScriptGen = stringsGen ["all"; "this script"]
+    let varGen = gen {
+        let! state = Arb.generate<_>
+        let! NonNull x = Arb.generate<_>
+        return [Expression.eString state x]
+    }
+    let valueExpressionsGen = Gen.listOf literalOrValueComplexGen
+    let operandGen = function
+        | OperandType.Block -> blockGen
+        | OperandType.Expression t ->
+            match t with
+            | TsType.StringSs strings -> stringsGen strings
+
+            // TODO:
+            | _ -> valueExpressionGen
+
+        | OperandType.ListVariableExpression _ -> listVarGen
+        | OperandType.Reporter -> reporterGen
+        | OperandType.Rotation -> rotationGen
+        | OperandType.Stop -> stopGen
+        | OperandType.StopScript -> stopScriptGen
+        | OperandType.Variable -> varGen
+        | OperandType.VariadicExpressions -> valueExpressionsGen
+
+    let g = gen {
+        let! state = Arb.generate<_>
+        let! UnwrapSymbol operator = Arb.generate<_>
+    
+        let! operands = knownAllOperatorMap.[operator].operands |> Gen.collectToSeq operandGen
+        let operands = Seq.concat operands |> Seq.toList
+        return ComplexExpression(state, operator, operands)
+    }
+    
+    let isValidComplexExpressionOperands operand operands =
+        match Map.tryFind operand knownAllOperatorMap with
+        | ValueNone -> false
+        | ValueSome { operands = specs } ->
+
+        let (|ExpressionKind|_|) = function
+            | Literal _ -> Some Kind.Expression
+            | Block _ -> Some Kind.Statement
+            | Complex(ComplexExpression(operator = KnownOperatorInfo(ValueSome { kind = kind }))) -> Some kind
+            | _ -> None
+            
+        let validateAndTakeOperands = function
+            | OperandType.Expression _, ExpressionKind Kind.Expression::operands
+            | OperandType.Block, Block _::operands
+            | OperandType.ListVariableExpression _, EString _::operands
+            | OperandType.Reporter, EString _::operands
+            | OperandType.Rotation, EString _::operands
+            | OperandType.Stop, EString _::operands
+            | OperandType.StopScript, EString _::operands
+            | OperandType.Variable, EString _::operands ->
+                Some operands
+
+            | OperandType.VariadicExpressions, operands ->
+                operands |> List.takeWhile (function ExpressionKind Kind.Expression -> true | _ -> false) |> Some
+
+            | _ -> None
+
+        let rec isValidOperands operands specs =
+            match operands, specs with
+            | [], [] -> true
+            | _::_, [] -> false
+            | operands, s::specs ->
+
+            match validateAndTakeOperands (s, operands) with
+            | Some operands -> isValidOperands operands specs
+            | _ -> false
+
+        isValidOperands operands specs
+
+    let s (ComplexExpression(state, operator, operands)) = seq {
+        for state, UnwrapSymbol operator, operands in Arb.shrink(state, wrapSymbol operator, operands) do
+            if isValidComplexExpressionOperands operator operands then
+                ComplexExpression(state, operator, operands)
+    }
+    Arb.fromGenShrink(g, s)
 
 type Arbs =
     static member KnownFooterStatementName() =
@@ -43,6 +157,13 @@ type Arbs =
         |> Map.toSeq
         |> Seq.map fst
         |> nameElements KnownComplexExpressionName (fun (KnownComplexExpressionName x) -> x)
+
+    static member KnownValueComplexExpressionName() =
+        knownAllOperatorMap
+        |> Map.toSeq
+        |> Seq.filter (fun (_, v) -> v.kind = Kind.Expression)
+        |> Seq.map fst
+        |> nameElements KnownValueComplexExpressionName (fun (KnownValueComplexExpressionName x) -> x)
 
     static member SValue() =
         let sString = gen {
@@ -66,18 +187,12 @@ type Arbs =
         }
         Arb.fromGenShrink(g, s)
 
+    static member KnownValueComplexExpression() =
+        complexExpressionArb KnownValueComplexExpressionName (fun (KnownValueComplexExpressionName x) -> x)
+        |> Arb.convert KnownValueComplexExpression (fun (KnownValueComplexExpression x) -> x)
+
     static member ComplexExpression() =
-        let g = gen {
-            let! state = Arb.generate<_>
-            let! KnownComplexExpressionName operator = Arb.generate<_>
-            let! operands = Arb.generate<_>
-            return ComplexExpression(state, operator, operands)
-        }
-        let s (ComplexExpression(state, operator, operands)) = seq {
-            for state, KnownComplexExpressionName operator, operands in Arb.shrink(state, KnownComplexExpressionName operator, operands) ->
-                ComplexExpression(state, operator, operands)
-        }
-        Arb.fromGenShrink(g, s)
+        complexExpressionArb KnownComplexExpressionName (fun (KnownComplexExpressionName x) -> x)
 
     static member FooterStatement() =
         let g = gen {
@@ -93,16 +208,43 @@ type Arbs =
         Arb.fromGenShrink(g, s)
 
     static member ListenerDefinition() =
+        let argumentGen spec = gen {
+            let! state = Arb.generate<_>
+            match spec with
+            | ListenerHeaderType.AnyOrKeyName
+            | ListenerHeaderType.EventName
+            | ListenerHeaderType.String ->
+                let! NonNull x = Arb.generate<_>
+                return Literal(state, SString x)
+
+            | ListenerHeaderType.Bool ->
+                let! x = Arb.generate<_>
+                return Literal(state, SBool x)
+
+            | ListenerHeaderType.Null ->
+                return Block(BlockExpression(state, []))
+        }
+        let isValidListenerArguments name arguments =
+            match Map.tryFind name knownListenerHeaderMap with
+            | ValueNone -> false
+            | ValueSome specs ->
+
+            if List.length arguments <> List.length specs then false else
+
+            // TODO:
+            true
+
         let g = gen {
             let! state = Arb.generate<_>
             let! KnownListenerHeaderName name = Arb.generate<_>
-            let! arguments = Arb.generate<_>
+            let! arguments = knownListenerHeaderMap.[name] |> Gen.collect argumentGen
             let! body = Arb.generate<_>
             return ListenerDefinition(state, name, arguments, body)
         }
         let s (ListenerDefinition(state, name, arguments, body)) = seq {
-            for state, KnownListenerHeaderName name, arguments, body in Arb.shrink (state, KnownListenerHeaderName name, arguments, body) ->
-                ListenerDefinition(state, name, arguments, body)
+            for state, KnownListenerHeaderName name, arguments, body in Arb.shrink (state, KnownListenerHeaderName name, arguments, body) do
+                if isValidListenerArguments name arguments then
+                    ListenerDefinition(state, name, arguments, body)
         }
         Arb.fromGenShrink(g, s)
 
@@ -132,13 +274,13 @@ type Arbs =
                 | Choice1Of4 x -> Listener x
                 | Choice2Of4 x -> Procedure x
                 | Choice3Of4 x -> Statements x
-                | Choice4Of4 x -> Expression x
+                | Choice4Of4(KnownValueComplexExpression x) -> Expression x
             )
             (function
                 | Listener x -> Choice1Of4 x
                 | Procedure x -> Choice2Of4 x
                 | Statements x -> Choice3Of4 x
-                | Expression x -> Choice4Of4 x
+                | Expression x -> Choice4Of4(KnownValueComplexExpression x)
             )
         |> Arb.filter (function
 


### PR DESCRIPTION
❌
```fs
Expression((), O.``%``, [])
Expression((), O.``%``, [Block(BlockExpression((), [])); Literal((), SNumber 10.)])
```
✔
```fs
Expression((), O.``%``, [Literal((), SString "a"); Literal((), SString "b")]
```

❌ のような、オペランドの数や種類が一致しない AST が生成されないように修正。
オペランドの型は見ないので ✔ のような式は生成されることがある。